### PR TITLE
Bump version to 1.0.4

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     and CI warns once <VersionPrefix> has caught up to the latest release tag.
   -->
   <PropertyGroup>
-    <VersionPrefix>1.0.3</VersionPrefix>
+    <VersionPrefix>1.0.4</VersionPrefix>
   </PropertyGroup>
 
   <!-- Licensing — GNU GPL v3 or later. Full text in the repo-root LICENSE file. -->


### PR DESCRIPTION
Ships the logistics-group editing UI (#7) on top of the save-fidelity fixes (#6, released as 1.0.3).

After merge: Actions → Release → Run workflow on `main` (or push `v1.0.4`).