### PR TITLE
Preserve save-file BOM instead of always writing one

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,12 +61,14 @@ and attaches them plus `SHA256SUMS.txt` to a GitHub Release.
 
 ## Architecture: the save-file format
 
-A Planet Crafter save file is a single UTF-8-with-BOM text file, not JSON overall. The framing (see
+A Planet Crafter save file is a single UTF-8 text file, not JSON overall. The framing (see
 `PlanetCrafterSaveFileSerializer`): a leading `\r`, then the 10 sections (index 0–9) joined by
 `\r@\r`, then a trailing `\r@`. A section holds either one JSON object or a list of JSON objects
-joined by `|\n`. The store writes the BOM (`PlanetCrafterSaveFileStore` uses a BOM-emitting UTF-8
-encoding); `Serialize` returns everything after it. Reproduce this exactly — an unedited
-load→save is asserted byte-identical, so a diff after an edit shows only the edit.
+joined by `|\n`. The **Steam** build writes the file with a leading UTF-8 BOM; the **Xbox / PC
+Game Pass** (WGS) build writes it without one — a spurious BOM makes the game reject the save
+("file error"), so `PlanetCrafterSaveFileStore.Save` preserves whatever the file already on disk
+has (BOM only for a brand-new path). `Serialize` returns everything after the BOM. Reproduce this
+exactly — an unedited load→save is asserted byte-identical, so a diff after an edit shows only the edit.
 `PlanetCrafterSaveFileSerializer` (`PCEdit.SaveFileHandler/PlanetCrafterSaveFileSerializer.cs`)
 hard-codes the section order — keep it in sync with `PlanetCrafterSaveFile`
 (`PCEdit.SaveFileHandler/Models/PlanetCrafterSaveFile.cs`):
@@ -96,7 +98,7 @@ Layering, each with a small interface for testability/DI:
 
 - `IJsonRecordSerializer` / `JsonRecordSerializer` — wraps `System.Text.Json` with camelCase naming and `WhenWritingNull` ignore semantics; deserializes/serializes a single record (section or list item) and wraps `JsonException` in `InvalidDataException` with the offending section index. Also holds `GameDecimalConverter` (the game writes every decimal with a fractional part — force `N.0`, never `N`). Every leaf model has a `[JsonExtensionData] ExtensionData` dictionary, so a JSON key no model names is **preserved** across a round-trip, not silently dropped. `WorldObject` goes further: the game's world-object key order is not stable (proven — the same pair of keys appears in both orders across records), so `WorldObjectConverter` records each record's key order on read and replays it on write, keeping unknown keys in place too. Tests: `RoundTrip_RealSampleSaveFile_ReserializesCharacterForCharacter` (whole-file, string-exact) and `PlanetCrafterSaveFileStoreTests.SaveThenLoad_...IsByteIdenticalOnDisk` (with BOM); `WorldObjectConverterTests` / `GameDecimalFormatTests` for the pieces; `GameFormatKeyMappingTests` pins the abbreviated-key spellings a symmetric model round-trip can't catch.
 - `IPlanetCrafterSaveFileSerializer` / `PlanetCrafterSaveFileSerializer` — splits/joins the 10 sections (framing above), delegating record-level (de)serialization to `IJsonRecordSerializer`. `Deserialize` is lenient about whitespace/line-endings; `Serialize` reproduces the game framing exactly.
-- `IPlanetCrafterSaveFileStore` / `PlanetCrafterSaveFileStore` — file I/O (`Load`/`Save` by path). `Load` uses `File.ReadAllText` (strips the BOM); `Save` writes UTF-8 **with** a BOM to match the game.
+- `IPlanetCrafterSaveFileStore` / `PlanetCrafterSaveFileStore` — file I/O (`Load`/`Save` by path). `Load` uses `File.ReadAllText` (strips any BOM); `Save` re-checks the target file's first bytes and writes UTF-8 with a BOM only if the existing file had one (or the path is new) — matching Steam-with-BOM and Game-Pass-without.
 
 Model conventions worth knowing before adding/editing a model in `PCEdit.SaveFileHandler/Models/`:
 - Fields that are always present in the save file are `required` properties; fields the game may omit are nullable (`decimal?`, `string?`, etc.) — get this right or `Save`/round-trip will crash or lose data.

--- a/PCEdit.SaveFileHandler.Tests/PlanetCrafterSaveFileStoreTests.cs
+++ b/PCEdit.SaveFileHandler.Tests/PlanetCrafterSaveFileStoreTests.cs
@@ -70,13 +70,41 @@ public sealed class PlanetCrafterSaveFileStoreTests : IDisposable
     }
 
     [Fact]
-    public void Save_WritesUtf8WithBom()
+    public void Save_ToANewPath_WritesUtf8WithBom()
     {
+        // No file on disk yet ("Save As" / first save) — match the Steam game, which emits a BOM.
         _store.Save(_tempFile, SaveFileFixtures.CreateEmpty());
 
         var bytes = File.ReadAllBytes(_tempFile);
 
         Assert.Equal([0xEF, 0xBB, 0xBF], bytes[..3]);
+    }
+
+    [Fact]
+    public void Save_OverAFileThatHasNoBom_KeepsItBomLess()
+    {
+        // The Xbox / PC Game Pass (WGS) build stores the save with no BOM; adding one corrupts it.
+        var source = Path.Combine(AppContext.BaseDirectory, "TestData", "mini-save.json");
+        var bomLess = File.ReadAllBytes(source)[3..];
+        File.WriteAllBytes(_tempFile, bomLess);
+
+        _store.Save(_tempFile, _store.Load(_tempFile));
+
+        var written = File.ReadAllBytes(_tempFile);
+        Assert.NotEqual([0xEF, 0xBB, 0xBF], written[..3]);
+        Assert.Equal(bomLess, written);
+    }
+
+    [Fact]
+    public void Save_OverAFileThatHasABom_KeepsTheBom()
+    {
+        var source = Path.Combine(AppContext.BaseDirectory, "TestData", "mini-save.json");
+        var original = File.ReadAllBytes(source);
+        File.WriteAllBytes(_tempFile, original);
+
+        _store.Save(_tempFile, _store.Load(_tempFile));
+
+        Assert.Equal(original, File.ReadAllBytes(_tempFile));
     }
 
     [Fact]

--- a/PCEdit.SaveFileHandler/PlanetCrafterSaveFileStore.cs
+++ b/PCEdit.SaveFileHandler/PlanetCrafterSaveFileStore.cs
@@ -6,9 +6,16 @@ namespace PCEdit.SaveFileHandler;
 public sealed class PlanetCrafterSaveFileStore(IPlanetCrafterSaveFileSerializer serializer)
     : IPlanetCrafterSaveFileStore
 {
-    // The game writes the save as UTF-8 with a leading BOM; match it so a load→save leaves the
-    // file byte-identical. (File.ReadAllText auto-detects and strips the BOM on the way in.)
-    private static readonly Encoding SaveEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: true);
+    // The Steam build writes the save as UTF-8 *with* a leading BOM; the Xbox / PC Game Pass (WGS)
+    // build writes it *without* one, starting straight at the '\r' framing byte. Prepending a BOM
+    // the file never had makes the game reject the save with a "file error", so Save preserves
+    // whatever framing the file already on disk has instead of forcing a BOM (issue #12).
+    // A path with no existing file (new save / "Save As") defaults to a BOM, matching the Steam
+    // game's own output. File.ReadAllText auto-detects and strips the BOM on the way in.
+    private static readonly byte[] Utf8Bom = [0xEF, 0xBB, 0xBF];
+
+    private static readonly Encoding Utf8WithBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: true);
+    private static readonly Encoding Utf8WithoutBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
 
     private readonly IPlanetCrafterSaveFileSerializer _serializer
         = serializer ?? throw new ArgumentNullException(nameof(serializer));
@@ -23,6 +30,23 @@ public sealed class PlanetCrafterSaveFileStore(IPlanetCrafterSaveFileSerializer 
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(path);
         ArgumentNullException.ThrowIfNull(saveFile);
-        File.WriteAllText(path, _serializer.Serialize(saveFile), SaveEncoding);
+
+        var encoding = FileStartsWithBom(path) ? Utf8WithBom : Utf8WithoutBom;
+        File.WriteAllText(path, _serializer.Serialize(saveFile), encoding);
+    }
+
+    // Only the Steam save carries a UTF-8 BOM. A file that does not exist yet is treated as
+    // BOM-prefixed so a brand-new save matches the Steam game's output.
+    private static bool FileStartsWithBom(string path)
+    {
+        if (!File.Exists(path))
+        {
+            return true;
+        }
+
+        Span<byte> head = stackalloc byte[3];
+        using var stream = File.OpenRead(path);
+        var read = stream.ReadAtLeast(head, head.Length, throwOnEndOfStream: false);
+        return read == head.Length && head.SequenceEqual(Utf8Bom);
     }
 }


### PR DESCRIPTION
## What

`PlanetCrafterSaveFileStore.Save` hard-coded a UTF-8 BOM on every write. The Steam build's saves carry a BOM; the **Xbox / PC Game Pass** (WGS) build writes them **without** one. Adding a BOM the file never had puts a `U+FEFF` before section 0's opening brace, and the game rejects the save with a **"file error"** on next load - for *any* edit, not just terraforming.

## Change

- `Save` checks the target file's first three bytes and emits a BOM only if the file already on disk had one.
- A path with no existing file (new save / "Save As") defaults to a BOM, matching the Steam game's own output.
- `Load` unchanged (`File.ReadAllText` already strips any BOM).

## Tests

Replaced `Save_WritesUtf8WithBom` with:
- `Save_ToANewPath_WritesUtf8WithBom`
- `Save_OverAFileThatHasNoBom_KeepsItBomLess` (asserts byte-identical round-trip)
- `Save_OverAFileThatHasABom_KeepsTheBom`

`PCEdit.SaveFileHandler.Tests` 54 passed, `PCEdit.App.Core.Tests` 138 passed, full solution builds clean.

Also verified manually against a real Game Pass WGS save blob: no-op load->save is byte-identical and stays BOM-less; editing a terraform level changes only the Terraformation section and adds no BOM; the edited file re-loads cleanly.

`CLAUDE.md` save-file-format section corrected (Steam has a BOM, Game Pass does not).

Fixes #13
