### PR TITLE
Release v1.1.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     and CI warns once <VersionPrefix> has caught up to the latest release tag.
   -->
   <PropertyGroup>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>1.1.1</VersionPrefix>
   </PropertyGroup>
 
   <!-- Licensing — GNU GPL v3 or later. Full text in the repo-root LICENSE file. -->

--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ Turkish); it follows the OS language on first run and can be switched in-app.
 Full history and downloads are on the
 [Releases page](https://github.com/Valkerran/PCEdit/releases).
 
+### v1.1.1
+
+- **Fix: saves edited on Xbox / PC Game Pass no longer corrupt.** The editor was adding a
+  UTF-8 byte-order mark that the Game Pass (WGS) build of the game does not write; on next
+  load the game reported a "file error". The editor now preserves whatever byte framing the
+  save already has (Steam saves keep their BOM). ([#13](https://github.com/Valkerran/PCEdit/issues/13))
+
 ### v1.1.0
 
 - **Inventories — filter by world.** On a save that spans more than one planet, the Inventories


### PR DESCRIPTION
Bumps `<VersionPrefix>` to **1.1.1** and adds the changelog entry.

Ships the fix from #14 / #13: the editor no longer prepends a UTF-8 BOM to saves that did not have one (Xbox / PC Game Pass WGS saves), which was making the game report a "file error" after any edit.

After merge: Actions -> Release -> Run workflow on `main` to cut `v1.1.1`.