### PR TITLE
Bump <VersionPrefix> to 1.1.2 for development

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     and CI warns once <VersionPrefix> has caught up to the latest release tag.
   -->
   <PropertyGroup>
-    <VersionPrefix>1.1.1</VersionPrefix>
+    <VersionPrefix>1.1.2</VersionPrefix>
   </PropertyGroup>
 
   <!-- Licensing — GNU GPL v3 or later. Full text in the repo-root LICENSE file. -->


### PR DESCRIPTION
Post-release housekeeping (RELEASING.md step 5).

Bumps `<VersionPrefix>` to **1.1.2** so pre-release builds off `main` are not stamped with the shipped `v1.1.1`. This also clears the `version-guard` CI warning. The next release re-bumps to whatever version it ships.