### PR TITLE
Bump <VersionPrefix> to 1.2.1 for development

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     and CI warns once <VersionPrefix> has caught up to the latest release tag.
   -->
   <PropertyGroup>
-    <VersionPrefix>1.2.0</VersionPrefix>
+    <VersionPrefix>1.2.1</VersionPrefix>
   </PropertyGroup>
 
   <!-- Licensing — GNU GPL v3 or later. Full text in the repo-root LICENSE file. -->


### PR DESCRIPTION
Post-release housekeeping, step 5 of `RELEASING.md`.

v1.2.0 is published, so `<VersionPrefix>` on `main` now equals the newest release tag — CI's `version-guard` job warns in that state as a reminder to bump. Raising it to 1.2.1 clears the warning and stops pre-release builds off `main` being stamped with the version that already shipped.

No code change; the next real PR retargets this as needed (minor for a feature, major for a break).