### PR TITLE
Bundle libicu in the Linux build so the AppImage starts everywhere

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,14 @@ jobs:
       - name: Build — PCEdit.Desktop
         run: dotnet build PCEdit.Desktop/PCEdit.Desktop.csproj -c Release
 
+      # The AppImage is only assembled at release time, so guard the ICU wiring here:
+      # without it the Linux build FailFasts at startup on a distro with no system libicu.
+      - name: Linux publish carries app-local ICU
+        shell: bash
+        run: |
+          dotnet publish PCEdit.Desktop/PCEdit.Desktop.csproj -c Release -r linux-x64 --self-contained true -o "$RUNNER_TEMP/icu-check"
+          deploy/verify-app-local-icu.sh "$RUNNER_TEMP/icu-check"
+
       - name: Generated files are in sync with the string catalog
         run: |
           python3 tools/i18n/gen_satellites.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -346,6 +346,17 @@ repo root — mirrored by `Disclaimer_Body` in the catalog and the AppStream `<d
 - `build-windows.ps1` — `win-x64` `dotnet publish` zipped with `Compress-Archive`. Unsigned.
 - `build-macos.sh <rid>` — assembles an unsigned `PCEdit.app` (generated `Info.plist`; `.icns` from
   `deploy/icon/` via `sips`+`iconutil` on macOS only) and zips it with `ditto`.
+- `verify-app-local-icu.sh <dir>` — asserts a Linux build carries its own ICU.
+
+**libicu is bundled on Linux, and only on Linux.** A self-contained publish does *not*
+include it — .NET `dlopen()`s the system copy and FailFasts at startup on a distro that has
+none (openSUSE Tumbleweed), which made the AppImage unlaunchable there. So
+`PCEdit.Desktop.csproj` references `Microsoft.ICU.ICU4C.Runtime` and sets
+`System.Globalization.AppLocalIcu` on `linux-*` RIDs only; **the package version
+(`<AppLocalIcuVersion>`) and the switch value must stay identical** — the switch *is* the
+`libicu*.so.<version>` filename suffix. Neither is visible to `ldd` (it is a `dlopen`), so
+`verify-app-local-icu.sh` guards both from `build-appimage.sh` and from CI. Do not add the
+package to the Windows or macOS publish: they use the OS ICU, and it has no `osx` RID.
 
 Release automation and the versioning rules live in `RELEASING.md`.
 

--- a/PCEdit.Desktop/PCEdit.Desktop.csproj
+++ b/PCEdit.Desktop/PCEdit.Desktop.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
@@ -18,6 +18,38 @@
         <!-- All 15 UI-language satellites of PCEdit.App.Core must ship. -->
         <SatelliteResourceLanguages>en;en-GB;fr;de;es-ES;zh-Hans;ru;pl;pt-PT;ko;ja;pt-BR;it;zh-Hant;tr</SatelliteResourceLanguages>
     </PropertyGroup>
+
+    <!--
+        App-local ICU (Linux only).
+
+        A self-contained publish does NOT bundle libicu - .NET dlopen()s the system one, and
+        FailFasts at startup ("Couldn't find a valid ICU package installed on the system") on a
+        distro that has none (openSUSE Tumbleweed ships without it). That made the AppImage,
+        which promises to be self-contained, unlaunchable there. The `ldd | grep 'not found'`
+        artifact check cannot catch it, because the load is a dlopen, not a link-time dependency.
+
+        So the Linux publish carries its own ICU: the Microsoft.ICU.ICU4C.Runtime package drops
+        libicu{uc,i18n,data}.so.$(AppLocalIcuVersion) next to the app, and the
+        System.Globalization.AppLocalIcu switch tells the runtime to load those by that exact
+        version suffix instead of probing the system. Keep the package version and the switch
+        value identical - the switch IS the filename suffix.
+
+        Windows (OS ICU since Win10 1703) and macOS (libicucore in the OS) need none of this, and
+        the package has no osx RID, so this stays scoped to non-musl linux-* RIDs. A plain
+        `dotnet build`/`dotnet test` with no RID is unaffected.
+
+        Verified by the CI "AppImage ships app-local ICU" step and by deploy/build-appimage.sh,
+        which both fail if the libraries or the switch go missing.
+    -->
+    <PropertyGroup>
+        <AppLocalIcuVersion>72.1.0.3</AppLocalIcuVersion>
+        <BundleAppLocalIcu Condition="'$(RuntimeIdentifier)' != '' and $(RuntimeIdentifier.StartsWith('linux-')) and !$(RuntimeIdentifier.StartsWith('linux-musl'))">true</BundleAppLocalIcu>
+    </PropertyGroup>
+
+    <ItemGroup Condition="'$(BundleAppLocalIcu)' == 'true'">
+        <PackageReference Include="Microsoft.ICU.ICU4C.Runtime" Version="$(AppLocalIcuVersion)" />
+        <RuntimeHostConfigurationOption Include="System.Globalization.AppLocalIcu" Value="$(AppLocalIcuVersion)" Trim="false" />
+    </ItemGroup>
 
     <ItemGroup>
         <AvaloniaResource Include="Assets/**" />

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -21,6 +21,7 @@ or manual dispatch and attaches the artifacts + `SHA256SUMS.txt` to a GitHub Rel
 | `com.valkerran.pcedit.metainfo.xml` | AppStream metadata — **generated**, do not hand-edit |
 | `icon/`                             | App icon: scalable `pcedit.svg` + rasterised PNGs (16–512 px) |
 | `build-appimage.sh`                 | Linux AppImage build → `artifacts/` |
+| `verify-app-local-icu.sh`           | Asserts a Linux build carries its own ICU (see below) |
 | `build-windows.ps1`                 | Windows `win-x64` zip → `artifacts/` |
 | `build-macos.sh`                    | macOS `.app` bundle zip (per RID) → `artifacts/` |
 
@@ -62,9 +63,35 @@ bundled runtime links against an old glibc and runs on newer distros:
 
 ### Runtime libraries on the target
 
-The runtime is bundled; only GUI/system libraries are expected, and they are present on
-every desktop Linux (X11 or XWayland): `libX11`, `libICE`, `libSM`, `fontconfig`,
-`libGL`. No bundling required.
+The .NET runtime is bundled; only GUI/system libraries are expected, and they are present
+on every desktop Linux (X11 or XWayland): `libX11`, `libICE`, `libSM`, `fontconfig`,
+`libGL`.
+
+### ICU — bundled, not borrowed
+
+**libicu is the one runtime library the AppImage carries itself.** A self-contained
+publish does *not* bundle it: .NET `dlopen()`s the system copy and FailFasts at startup
+— *"Couldn't find a valid ICU package installed on the system"* — on a distro that has
+none. openSUSE Tumbleweed ships without it, so the AppImage could not launch there at
+all ([issue #4](https://github.com/Valkerran/PCEdit/issues/4)).
+
+`PCEdit.Desktop.csproj` therefore pulls `Microsoft.ICU.ICU4C.Runtime`
+(`<AppLocalIcuVersion>`) on `linux-*` RIDs and sets the
+`System.Globalization.AppLocalIcu` runtimeconfig switch to the same version, so the
+runtime loads `libicu{uc,i18n,data}.so.<version>` from the app folder and never probes
+the system. The package version and the switch value **must stay identical** — the
+switch *is* the filename suffix. Windows (OS ICU) and macOS (`libicucore`) are excluded.
+
+Two consequences worth knowing:
+
+- The AppImage grew from ~43 MB to ~56.5 MB. That is the price of launching everywhere.
+- Every distro now gets the same ICU 72 collation and CLDR data instead of whatever the
+  system happened to ship — more deterministic, but it does not track distro updates.
+
+Neither the libraries nor the switch are visible to `ldd` (the load is a `dlopen`, not a
+link-time dependency), so `verify-app-local-icu.sh` checks both. `build-appimage.sh` runs
+it on the extracted AppImage and CI runs it on a `linux-x64` publish; either failing means
+the build would not start on a distro without libicu.
 
 ### CJK fonts
 
@@ -141,6 +168,7 @@ WAYLAND_DISPLAY= ./PCEdit-*-x86_64.AppImage --appimage-extract-and-run      # fo
 LANG=ja_JP.UTF-8 ./PCEdit-*-x86_64.AppImage --appimage-extract-and-run     # locale + CJK glyphs
 ./PCEdit-*-x86_64.AppImage --appimage-extract >/dev/null && \
   ldd squashfs-root/usr/bin/PCEdit | grep -i 'not found'                   # must print nothing
+../deploy/verify-app-local-icu.sh squashfs-root                            # bundled ICU present
 ```
 Per distro confirm: window renders; `Standard-2.json` loads/edits/saves/round-trips; the
 disclaimer shows once and the ack persists (`~/.config/PCEdit/settings.json`); no
@@ -188,11 +216,16 @@ This is called out in the Release body. `LSMinimumSystemVersion` is 11.0.
 
 ## Tested on
 
+✅ = the full per-distro checklist above. 🟡 = launch only (the window renders and
+stays up); the save round-trip, disclaimer persistence and CJK checks were not run.
+
 | Distro | glibc | Result | Date |
 |---|---|---|---|
 | Ubuntu 22.04 (WSL2, build host) | 2.35 | ✅ built (42.9 MB); `ldd` clean; GUI launches under WSLg | 2026-08-28 |
+| Ubuntu 22.04 (WSL2, build host) | 2.35 | 🟡 rebuilt with bundled ICU (56.5 MB); `ldd` clean; ICU check passes; GUI launches | 2026-09-01 |
 | Ubuntu 24.04 | | _pending_ | |
-| Debian 12 | | _pending_ | |
-| Fedora | | _pending_ | |
-| Arch | | _pending_ | |
-| openSUSE Tumbleweed | | _pending_ | |
+| Debian 12 | | 🟡 `linux-x64` publish launches (AppImage not run) | 2026-09-01 |
+| Fedora 43 | | 🟡 AppImage launches | 2026-09-01 |
+| Arch | | 🟡 AppImage launches | 2026-09-01 |
+| openSUSE Tumbleweed | | 🟡 AppImage launches — **fatal before the bundled ICU**: no system libicu | 2026-09-01 |
+| Ubuntu 20.04 | | 🟡 `linux-x64` publish launches (AppImage not run) | 2026-09-01 |

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -63,9 +63,13 @@ bundled runtime links against an old glibc and runs on newer distros:
 
 ### Runtime libraries on the target
 
-The .NET runtime is bundled; only GUI/system libraries are expected, and they are present
-on every desktop Linux (X11 or XWayland): `libX11`, `libICE`, `libSM`, `fontconfig`,
-`libGL`.
+The .NET runtime is bundled; only GUI/system libraries are expected, and any desktop Linux
+install has them (X11 or XWayland): `libX11`, `libICE`, `libSM`, `fontconfig`, `libGL`.
+
+A **bare** image is another matter — the WSL Ubuntu 24.04 rootfs has no `libICE`/`libSM`,
+and Avalonia `dlopen`s those as well, so the app dies with a `DllNotFoundException` from
+`X11PlatformLifetimeEvents..ctor` that `ldd` never predicted. Step 2 of the distro matrix
+below installs them; a real desktop pulls them in with the DE.
 
 ### ICU — bundled, not borrowed
 
@@ -223,9 +227,9 @@ stays up); the save round-trip, disclaimer persistence and CJK checks were not r
 |---|---|---|---|
 | Ubuntu 22.04 (WSL2, build host) | 2.35 | ✅ built (42.9 MB); `ldd` clean; GUI launches under WSLg | 2026-08-28 |
 | Ubuntu 22.04 (WSL2, build host) | 2.35 | 🟡 rebuilt with bundled ICU (56.5 MB); `ldd` clean; ICU check passes; GUI launches | 2026-09-01 |
-| Ubuntu 24.04 | | _pending_ | |
+| Ubuntu 24.04 | 2.39 | 🟡 AppImage launches once `libice6`/`libsm6` are installed; bundled ICU proven to win over system ICU 74 | 2026-09-01 |
 | Debian 12 | | 🟡 `linux-x64` publish launches (AppImage not run) | 2026-09-01 |
 | Fedora 43 | | 🟡 AppImage launches | 2026-09-01 |
-| Arch | | 🟡 AppImage launches | 2026-09-01 |
+| Arch | 2.44 | 🟡 AppImage launches | 2026-09-01 |
 | openSUSE Tumbleweed | | 🟡 AppImage launches — **fatal before the bundled ICU**: no system libicu | 2026-09-01 |
 | Ubuntu 20.04 | | 🟡 `linux-x64` publish launches (AppImage not run) | 2026-09-01 |

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -223,11 +223,17 @@ This is called out in the Release body. `LSMinimumSystemVersion` is 11.0.
 ✅ = the full per-distro checklist above. 🟡 = launch only (the window renders and
 stays up); the save round-trip, disclaimer persistence and CJK checks were not run.
 
+The checklist can be **driven** rather than clicked: run the AppImage against an `Xvfb`
+display and use `xdotool` (`import` for screenshots). Do not try that against WSLg — its
+RAIL layer forwards only real Windows input, so synthetic clicks and keys are silently
+dropped (the pointer still moves and the app still shows hover states, which makes it look
+like it should be working). Rendering is fine to verify under WSLg; interaction is not.
+
 | Distro | glibc | Result | Date |
 |---|---|---|---|
 | Ubuntu 22.04 (WSL2, build host) | 2.35 | ✅ built (42.9 MB); `ldd` clean; GUI launches under WSLg | 2026-08-28 |
 | Ubuntu 22.04 (WSL2, build host) | 2.35 | 🟡 rebuilt with bundled ICU (56.5 MB); `ldd` clean; ICU check passes; GUI launches | 2026-09-01 |
-| Ubuntu 24.04 | 2.39 | 🟡 AppImage launches once `libice6`/`libsm6` are installed; bundled ICU proven to win over system ICU 74 | 2026-09-01 |
+| Ubuntu 24.04 | 2.39 | ✅ full checklist (needs `libice6`/`libsm6`; Noto CJK for the glyph check); bundled ICU proven to win over system ICU 74 | 2026-09-01 |
 | Debian 12 | | 🟡 `linux-x64` publish launches (AppImage not run) | 2026-09-01 |
 | Fedora 43 | | 🟡 AppImage launches | 2026-09-01 |
 | Arch | 2.44 | 🟡 AppImage launches | 2026-09-01 |

--- a/deploy/build-appimage.sh
+++ b/deploy/build-appimage.sh
@@ -80,6 +80,7 @@ found=0
 for f in "$SCRIPT_DIR"/OUT/*.AppImage; do
     [ -e "$f" ] || continue
     cp -v "$f" "$ARTIFACTS/"
+    APPIMAGE="$ARTIFACTS/$(basename "$f")"
     found=1
 done
 
@@ -87,6 +88,13 @@ if [ "$found" -eq 0 ]; then
     echo "!! No .AppImage produced in $SCRIPT_DIR/OUT" >&2
     exit 1
 fi
+
+# The AppImage must carry its own ICU - see deploy/verify-app-local-icu.sh (issue #4).
+echo ">> Verifying app-local ICU in $APPIMAGE"
+_icu_check="$(mktemp -d)"
+trap 'rm -rf "$_icu_check"' EXIT
+( cd "$_icu_check" && "$APPIMAGE" --appimage-extract >/dev/null )
+"$SCRIPT_DIR/verify-app-local-icu.sh" "$_icu_check/squashfs-root"
 
 echo ">> Done. Artifacts in $ARTIFACTS:"
 ls -la "$ARTIFACTS"/*.AppImage

--- a/deploy/verify-app-local-icu.sh
+++ b/deploy/verify-app-local-icu.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Assert that a Linux build of PCEdit carries its own ICU (GitHub issue #4).
+#
+# Usage:
+#   deploy/verify-app-local-icu.sh <directory>
+#
+# <directory> is either a `dotnet publish -r linux-x64` output folder or an extracted
+# AppImage (squashfs-root); the files are located by search, so either shape works.
+#
+# A self-contained publish does not bundle libicu - the runtime dlopen()s the system copy
+# and FailFasts at startup on a distro that ships without one (openSUSE Tumbleweed). The
+# Linux publish therefore ships libicu{uc,i18n,data}.so.<version> next to the app and sets
+# the System.Globalization.AppLocalIcu switch to that same version (see PCEdit.Desktop.csproj).
+# Neither half is visible to `ldd` - the load is a dlopen - so it gets checked here instead,
+# from both deploy/build-appimage.sh and the CI workflow.
+set -euo pipefail
+
+DIR="${1:-}"
+if [ -z "$DIR" ] || [ ! -d "$DIR" ]; then
+    echo "usage: $0 <publish-or-extracted-appimage-directory>" >&2
+    exit 2
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CSPROJ="$SCRIPT_DIR/../PCEdit.Desktop/PCEdit.Desktop.csproj"
+
+ICU="$(sed -n 's|.*<AppLocalIcuVersion>\([^<]*\)</AppLocalIcuVersion>.*|\1|p' "$CSPROJ")"
+if [ -z "$ICU" ]; then
+    echo "!! <AppLocalIcuVersion> not found in $CSPROJ" >&2
+    exit 1
+fi
+
+fail=0
+
+for lib in libicuuc libicui18n libicudata; do
+    if [ -z "$(find "$DIR" -name "$lib.so.$ICU" -print -quit)" ]; then
+        echo "!! $lib.so.$ICU is missing from $DIR" >&2
+        fail=1
+    fi
+done
+
+RUNTIMECONFIG="$(find "$DIR" -name PCEdit.runtimeconfig.json -print -quit)"
+if [ -z "$RUNTIMECONFIG" ]; then
+    echo "!! PCEdit.runtimeconfig.json is missing from $DIR" >&2
+    fail=1
+elif ! grep -q "\"System.Globalization.AppLocalIcu\"[[:space:]]*:[[:space:]]*\"$ICU\"" "$RUNTIMECONFIG"; then
+    echo "!! System.Globalization.AppLocalIcu is not set to $ICU in $RUNTIMECONFIG" >&2
+    fail=1
+fi
+
+if [ "$fail" -ne 0 ]; then
+    echo "!! App-local ICU is not wired up - this build would not start on a distro without libicu." >&2
+    exit 1
+fi
+
+echo ">> App-local ICU $ICU verified in $DIR"


### PR DESCRIPTION
## The bug

A `dotnet publish --self-contained` does **not** bundle libicu — .NET `dlopen()`s the
system copy at startup and `FailFast`s when there isn't one:

```
Couldn't find a valid ICU package installed on the system...
   at System.Globalization.GlobalizationMode+Settings..cctor()
   at Avalonia.Platform.AssetLoader.RegisterResUriParsers()
   at PCEdit.Desktop.Program.Main(String[] args)
```

Reproduced on **openSUSE Tumbleweed**, which ships no libicu — the AppImage could not
launch there at all. Ubuntu 20.04/22.04/24.04, Debian, Fedora 43 and Arch all happen to
have it, which is why this went unnoticed. The Release workflow's
`ldd | grep 'not found'` check can never catch it: the load is a `dlopen`, not a
link-time dependency.

## The fix

`PCEdit.Desktop.csproj` now ships ICU with the app on Linux — `Microsoft.ICU.ICU4C.Runtime`
drops `libicu{uc,i18n,data}.so.72.1.0.3` next to the binary, and the
`System.Globalization.AppLocalIcu` runtimeconfig switch points the runtime at those instead
of probing the system.

Scoped to non-musl `linux-*` RIDs: Windows uses OS ICU, macOS uses `libicucore`, the package
has no `osx` RID, and a no-RID build (dev inner loop, both test projects) is untouched.
Verified — the `win-x64` and `osx-arm64` publishes contain no ICU files and no switch.

Because neither half is visible to `ldd`, `deploy/verify-app-local-icu.sh` asserts both over
a publish folder or an extracted AppImage. `build-appimage.sh` runs it on the real artifact;
CI runs it on a `linux-x64` publish, so a regression fails the PR rather than the next
release build.

## Verified

| | before | after |
|---|---|---|
| openSUSE Tumbleweed (no system libicu) | ICU `FailFast` at startup | window opens and stays up |
| Ubuntu 22.04 / 20.04 / Debian / Fedora 43 / Arch | worked | still works |

Both test projects green (65 + 158). A real AppImage was built through
`deploy/build-appimage.sh` on WSL Ubuntu 22.04 (the CI base) and run on openSUSE, Ubuntu
22.04, Arch and Fedora 43.

## Trade-offs

- **Size**: the AppImage goes from ~43 MB to ~56.5 MB (ICU's data library is the bulk).
- **Determinism**: every distro now gets the same ICU 72 collation and CLDR data rather
  than whatever the system shipped. Deterministic, but it no longer tracks distro updates.

## Not done

- **No version bump.** `<VersionPrefix>` is already `1.2.1` and the newest tag is `v1.2.0`,
  so `main` stays releasable as-is; bumping would skip an unreleased version.
- The `Tested on` table rows are marked launch-only — the save round-trip, disclaimer
  persistence and CJK-glyph checks from the manual checklist were not run.

Fixes #4
