### PR TITLE
Docs: libicu note, broken GitHub links, missing changelog entries

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     and CI warns once <VersionPrefix> has caught up to the latest release tag.
   -->
   <PropertyGroup>
-    <VersionPrefix>1.2.1</VersionPrefix>
+    <VersionPrefix>1.2.2</VersionPrefix>
   </PropertyGroup>
 
   <!-- Licensing — GNU GPL v3 or later. Full text in the repo-root LICENSE file. -->

--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ inventories normally.
 
 **Linux:** grab `PCEdit-*-x86_64.AppImage` from the
 [latest release](https://github.com/waldog78/PCEdit/releases/latest). It bundles the .NET
-runtime — no install needed.
+runtime and ICU — no install needed, on any distro.
 
 ```bash
 chmod +x PCEdit-*-x86_64.AppImage
 ./PCEdit-*-x86_64.AppImage
 ```
 
-If your distro has no FUSE or libicu, either install fuse and libicu for your distro or run `./PCEdit-*-x86_64.AppImage --appimage-extract-and-run`.
+If your distro has no FUSE, either install it or run `./PCEdit-*-x86_64.AppImage --appimage-extract-and-run`.
 For CJK menus, install your distro's Noto CJK font package.
 
 **Windows:** Just grab the appropriate zip file, extract and run PCEdit.exe


### PR DESCRIPTION
Docs cleanup around the v1.2.1 release.

**1. libicu no longer needs installing.** The download section still said:

> If your distro has no FUSE or libicu, either install fuse and libicu for your distro or run …

Since v1.2.1 the AppImage carries its own ICU, so that sent people to fix a problem they no
longer have. Folded into the "no install needed" sentence, where a reader looks for it; the
FUSE half stays, because it is still true.

**2. The GitHub links pointed at the wrong repository.** The README's Linux download link
went to `github.com/waldog78/PCEdit` — so the main download link was broken for everyone.
The same wrong owner sat in `tools/i18n/gen_metainfo.py`, which puts it in the AppStream
**homepage and bugtracker URLs shipped inside the AppImage**: anyone following "report a
bug" from the desktop entry landed nowhere. Fixed at the generator and regenerated; only
those two lines move.

**3. The README changelog stopped at v1.1.1.** Adds v1.2.0 (2.102 support, item catalog
278 → 466) and v1.2.1 (the libicu fix, stating the 43.0 → 56.5 MB size change and that
Windows/macOS are unaffected).

**4. `RELEASING.md` step 4 only mandated the macOS note**, which is why v1.2.1's size change
would have shipped unexplained. Generalised to any user-visible packaging change — size,
runtime dependency, artifact name, minimum OS — including naming who is *not* affected, and
mirroring the entry into the README changelog. v1.2.1 is the worked example.

Also bumps `<VersionPrefix>` to 1.2.2 (RELEASING.md step 5): 1.2.1 has shipped, so the prop
equals the newest tag and CI's version-guard warns on every PR until it moves.

Verified: `gen_satellites.py` and `gen_metainfo.py` re-run clean (no drift beyond the two
URL lines), `PCEdit.App.Core.Tests` green (158).
