### PR TITLE
Docs: fix the broken GitHub links, add the missing changelog entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,25 @@ Turkish); it follows the OS language on first run and can be switched in-app.
 Full history and downloads are on the
 [Releases page](https://github.com/Valkerran/PCEdit/releases).
 
+### v1.2.1
+
+- **Fix: the Linux AppImage now starts on distros with no system `libicu`.** A self-contained
+  build does not bundle ICU, and .NET aborts at startup when the system has none — so on
+  openSUSE Tumbleweed, and on minimal or container images generally, PCEdit would not launch
+  at all. The AppImage now carries its own ICU. It is larger for it: **56.5 MB, up from
+  43.0 MB**. Windows and macOS are unaffected — they use the ICU in the OS.
+  ([#4](https://github.com/Valkerran/PCEdit/issues/4))
+
+### v1.2.0
+
+- **Planet Crafter 2.102 (the *Skeo* update) is supported.** The save format barely moved:
+  one new key (`logisticsPaused`) on the unlocks section, and nothing else across all ten
+  sections, on Steam and Game Pass alike. Saves from 2.008 still open and still save back
+  unchanged. ([#17](https://github.com/Valkerran/PCEdit/pull/17))
+- **Item catalog: 278 → 466 items.** The catalog had been seeded from a single save, so
+  plenty of real content showed up under its raw in-game id. Anything still unnamed remains
+  editable and moves between inventories normally.
+
 ### v1.1.1
 
 - **Fix: saves edited on Xbox / PC Game Pass no longer corrupt.** The editor was adding a

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ inventories normally.
 ## Download
 
 **Linux:** grab `PCEdit-*-x86_64.AppImage` from the
-[latest release](https://github.com/waldog78/PCEdit/releases/latest). It bundles the .NET
+[latest release](https://github.com/Valkerran/PCEdit/releases/latest). It bundles the .NET
 runtime and ICU — no install needed, on any distro.
 
 ```bash

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -63,6 +63,18 @@ Rules the pipelines enforce:
    app and choose **Open** (or run `xattr -dr com.apple.quarantine PCEdit.app`).
    ```
 
+   **And call out any user-visible packaging change in the same section.** The
+   auto-generated notes list PR titles, which almost never convey that the download behaves
+   differently — a notable size change, a new or dropped runtime dependency, a renamed or
+   added artifact, a raised minimum OS. Say what changed, by how much, and why, and say who
+   is *not* affected: a reader who sees "+13 MB" on Linux will wonder about their own
+   platform. Also add the same entry to the README changelog, which is what people read
+   before downloading.
+
+   v1.2.1 is the worked example — bundling ICU took the AppImage from 43.0 MB to 56.5 MB,
+   so its notes lead with those numbers, give the reason (it would not start at all on a
+   distro with no system `libicu`), and state that Windows and macOS are unchanged.
+
 5. **Bump again for development** (optional but tidy): raise `<VersionPrefix>` to the next
    planned version on `main` so pre-release builds are not stamped with the shipped version.
 

--- a/deploy/com.valkerran.pcedit.metainfo.xml
+++ b/deploy/com.valkerran.pcedit.metainfo.xml
@@ -64,8 +64,8 @@
     <p xml:lang="tr">PCEdit, Planet Crafter kayıt dosyalarını doğrudan düzenler. Hatalı bir düzenleme bir kaydı bozabilir ve ilerlemenizi kaybettirebilir. Düzenlemeden önce kayıt dosyanızın her zaman bir yedeğini tutun. Bu yazılım, hiçbir garanti olmaksızın «olduğu gibi» sağlanır.</p>
   </description>
   <launchable type="desktop-id">com.valkerran.pcedit.desktop</launchable>
-  <url type="homepage">https://github.com/waldog78/PCEdit</url>
-  <url type="bugtracker">https://github.com/waldog78/PCEdit/issues</url>
+  <url type="homepage">https://github.com/Valkerran/PCEdit</url>
+  <url type="bugtracker">https://github.com/Valkerran/PCEdit/issues</url>
   <developer id="com.valkerran">
     <name>Walter Smart</name>
   </developer>

--- a/tools/i18n/gen_metainfo.py
+++ b/tools/i18n/gen_metainfo.py
@@ -99,8 +99,8 @@ def main() -> int:
     w("  </description>")
 
     w('  <launchable type="desktop-id">com.valkerran.pcedit.desktop</launchable>')
-    w('  <url type="homepage">https://github.com/waldog78/PCEdit</url>')
-    w('  <url type="bugtracker">https://github.com/waldog78/PCEdit/issues</url>')
+    w('  <url type="homepage">https://github.com/Valkerran/PCEdit</url>')
+    w('  <url type="bugtracker">https://github.com/Valkerran/PCEdit/issues</url>')
 
     w('  <developer id="com.valkerran">')
     w("    <name>Walter Smart</name>")


### PR DESCRIPTION
The tail of #27. That PR was merged while this branch was still being pushed to, so it
landed only the first two commits (the libicu note and the version bump). These three did
not make it:

**1. The GitHub links pointed at the wrong repository.** The README's Linux download link
went to `github.com/waldog78/PCEdit` — so the main download link was broken for everyone.
The same wrong owner sat in `tools/i18n/gen_metainfo.py`, which puts it in the AppStream
**homepage and bugtracker URLs shipped inside the AppImage**: anyone following "report a
bug" from the desktop entry landed nowhere. Fixed at the generator and regenerated; only
those two lines move.

**2. The README changelog stopped at v1.1.1.** Adds v1.2.0 (2.102 support, item catalog
278 → 466) and v1.2.1 (the libicu fix, stating the 43.0 → 56.5 MB size change and that
Windows/macOS are unaffected).

**3. `RELEASING.md` step 4 only mandated the macOS note**, which is why v1.2.1's size change
would have shipped unexplained. Generalised to any user-visible packaging change — size,
runtime dependency, artifact name, minimum OS — including naming who is *not* affected, and
mirroring the entry into the README changelog. v1.2.1 is the worked example.

`<VersionPrefix>` is already 1.2.2 from #27, so no further bump here.

Verified: `gen_satellites.py` and `gen_metainfo.py` re-run clean (no drift beyond the two
URL lines), `PCEdit.App.Core.Tests` green (158).
