### PR TITLE
Move the changelog into CHANGELOG.md, require an entry with every version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,51 @@
+# Changelog
+
+What changed in each release of PCEdit. Downloads for every version are on the
+[Releases page](https://github.com/Valkerran/PCEdit/releases); the newest is on the
+[latest release](https://github.com/Valkerran/PCEdit/releases/latest) page.
+
+## v1.2.2
+
+- **Fix: the AppImage's "report a bug" and homepage links pointed nowhere.** Every release
+  up to v1.2.1 shipped AppStream metadata naming a repository that does not exist, so those
+  links led to a 404 from the desktop entry. The application itself is unchanged from
+  v1.2.1. ([#28](https://github.com/Valkerran/PCEdit/pull/28))
+
+## v1.2.1
+
+- **Fix: the Linux AppImage now starts on distros with no system `libicu`.** A self-contained
+  build does not bundle ICU, and .NET aborts at startup when the system has none — so on
+  openSUSE Tumbleweed, and on minimal or container images generally, PCEdit would not launch
+  at all. The AppImage now carries its own ICU. It is larger for it: **56.5 MB, up from
+  43.0 MB**. Windows and macOS are unaffected — they use the ICU in the OS.
+  ([#4](https://github.com/Valkerran/PCEdit/issues/4))
+
+## v1.2.0
+
+- **Planet Crafter 2.102 (the *Skeo* update) is supported.** The save format barely moved:
+  one new key (`logisticsPaused`) on the unlocks section, and nothing else across all ten
+  sections, on Steam and Game Pass alike. Saves from 2.008 still open and still save back
+  unchanged. ([#17](https://github.com/Valkerran/PCEdit/pull/17))
+- **Item catalog: 278 → 466 items.** The catalog had been seeded from a single save, so
+  plenty of real content showed up under its raw in-game id. Anything still unnamed remains
+  editable and moves between inventories normally.
+
+## v1.1.1
+
+- **Fix: saves edited on Xbox / PC Game Pass no longer corrupt.** The editor was adding a
+  UTF-8 byte-order mark that the Game Pass (WGS) build of the game does not write; on next
+  load the game reported a "file error". The editor now preserves whatever byte framing the
+  save already has (Steam saves keep their BOM). ([#13](https://github.com/Valkerran/PCEdit/issues/13))
+
+## v1.1.0
+
+- **Inventories — filter by world.** On a save that spans more than one planet, the Inventories
+  page gains a **World** filter. Inventories that can't be matched to a planet (drones, vehicles,
+  rockets, unplaced buffers) group under *Unknown world*.
+- **Teleport — worlds.** Each landmark shows the planet it sits on and the list filters to the
+  chosen destination world. Picking a destination world different from where the player stands
+  fills X / Y / Z from that world's arrival point, and *Use current position* now restores the
+  player's world as well as their coordinates.
+- **Teleport — multiplayer note** about non-host players (see [Using the editor](README.md#teleport)).
+- **About page** now lists the game's default save-file locations per platform.
+- Fixes: *Use current position* no longer leaves a stale world selected.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ logistics catalogs via `tools/item-catalog/` (no CI guard — only a hand-edited
 followed by a re-run keeps the JSON honest). Commit messages say what changed and why; see
 [Git commit conventions](#git-commit-conventions) for the trailer rule.
 
-### 5. Bump the version last, before opening the PR
+### 5. Bump the version and write the changelog entry, before opening the PR
 
 The final phase bumps `<VersionPrefix>` in the repo-root `Directory.Build.props` (semver:
 patch for a bug fix, minor for a feature or new game-version support, major for a breaking
@@ -80,6 +80,20 @@ tag and publishes the artifacts, with no follow-up commit needed.
 CI's `version-guard` job fails if `<VersionPrefix>` is malformed or *behind* the newest release
 tag, and the Release workflow refuses to build if a pushed tag disagrees with it. The full
 release procedure is in `RELEASING.md`.
+
+**The same phase adds the entry to `CHANGELOG.md`** — a `## vX.Y.Z` section for the version
+being bumped to, at the top of the list, in the voice of the existing entries: what changed
+for someone *using* the app, not what changed in the code. A version bump carrying
+user-visible change but no entry is an incomplete phase: the next release ships straight from
+`main`, and no later step would catch the omission — which is exactly how v1.2.0 and v1.2.1
+came to ship undocumented.
+
+The exception is a bare *bump for development* after a release (`RELEASING.md` step 5), which
+carries nothing yet — its entry arrives with the change that fills the version.
+
+Call out anything user-visible beyond the fix itself: a size change, a new or dropped runtime
+dependency, a renamed artifact, a raised minimum OS — and say which platforms are *not*
+affected. `RELEASING.md` step 4 mirrors the entry into the GitHub Release body.
 
 ## Commands
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     and CI warns once <VersionPrefix> has caught up to the latest release tag.
   -->
   <PropertyGroup>
-    <VersionPrefix>1.2.2</VersionPrefix>
+    <VersionPrefix>1.2.3</VersionPrefix>
   </PropertyGroup>
 
   <!-- Licensing — GNU GPL v3 or later. Full text in the repo-root LICENSE file. -->

--- a/README.md
+++ b/README.md
@@ -137,51 +137,5 @@ Linux Steam locations may depend on the drive you have installed the game to. Re
 
 ## Changelog
 
-Full history and downloads are on the
+What changed in each release is in [CHANGELOG.md](CHANGELOG.md). Downloads are on the
 [Releases page](https://github.com/Valkerran/PCEdit/releases).
-
-### v1.2.2
-
-- **Fix: the AppImage's "report a bug" and homepage links pointed nowhere.** Every release
-  up to v1.2.1 shipped AppStream metadata naming a repository that does not exist, so those
-  links led to a 404 from the desktop entry. The application itself is unchanged from
-  v1.2.1. ([#28](https://github.com/Valkerran/PCEdit/pull/28))
-
-### v1.2.1
-
-- **Fix: the Linux AppImage now starts on distros with no system `libicu`.** A self-contained
-  build does not bundle ICU, and .NET aborts at startup when the system has none — so on
-  openSUSE Tumbleweed, and on minimal or container images generally, PCEdit would not launch
-  at all. The AppImage now carries its own ICU. It is larger for it: **56.5 MB, up from
-  43.0 MB**. Windows and macOS are unaffected — they use the ICU in the OS.
-  ([#4](https://github.com/Valkerran/PCEdit/issues/4))
-
-### v1.2.0
-
-- **Planet Crafter 2.102 (the *Skeo* update) is supported.** The save format barely moved:
-  one new key (`logisticsPaused`) on the unlocks section, and nothing else across all ten
-  sections, on Steam and Game Pass alike. Saves from 2.008 still open and still save back
-  unchanged. ([#17](https://github.com/Valkerran/PCEdit/pull/17))
-- **Item catalog: 278 → 466 items.** The catalog had been seeded from a single save, so
-  plenty of real content showed up under its raw in-game id. Anything still unnamed remains
-  editable and moves between inventories normally.
-
-### v1.1.1
-
-- **Fix: saves edited on Xbox / PC Game Pass no longer corrupt.** The editor was adding a
-  UTF-8 byte-order mark that the Game Pass (WGS) build of the game does not write; on next
-  load the game reported a "file error". The editor now preserves whatever byte framing the
-  save already has (Steam saves keep their BOM). ([#13](https://github.com/Valkerran/PCEdit/issues/13))
-
-### v1.1.0
-
-- **Inventories — filter by world.** On a save that spans more than one planet, the Inventories
-  page gains a **World** filter. Inventories that can't be matched to a planet (drones, vehicles,
-  rockets, unplaced buffers) group under *Unknown world*.
-- **Teleport — worlds.** Each landmark shows the planet it sits on and the list filters to the
-  chosen destination world. Picking a destination world different from where the player stands
-  fills X / Y / Z from that world's arrival point, and *Use current position* now restores the
-  player's world as well as their coordinates.
-- **Teleport — multiplayer note** about non-host players (see [Using the editor](#teleport)).
-- **About page** now lists the game's default save-file locations per platform.
-- Fixes: *Use current position* no longer leaves a stale world selected.

--- a/README.md
+++ b/README.md
@@ -40,50 +40,6 @@ Turkish); it follows the OS language on first run and can be switched in-app.
 
 **Note** - all non-english languages are AI translated. If anyone spots any translation issues, raise an issue request.
 
-## Changelog
-
-Full history and downloads are on the
-[Releases page](https://github.com/Valkerran/PCEdit/releases).
-
-### v1.2.1
-
-- **Fix: the Linux AppImage now starts on distros with no system `libicu`.** A self-contained
-  build does not bundle ICU, and .NET aborts at startup when the system has none — so on
-  openSUSE Tumbleweed, and on minimal or container images generally, PCEdit would not launch
-  at all. The AppImage now carries its own ICU. It is larger for it: **56.5 MB, up from
-  43.0 MB**. Windows and macOS are unaffected — they use the ICU in the OS.
-  ([#4](https://github.com/Valkerran/PCEdit/issues/4))
-
-### v1.2.0
-
-- **Planet Crafter 2.102 (the *Skeo* update) is supported.** The save format barely moved:
-  one new key (`logisticsPaused`) on the unlocks section, and nothing else across all ten
-  sections, on Steam and Game Pass alike. Saves from 2.008 still open and still save back
-  unchanged. ([#17](https://github.com/Valkerran/PCEdit/pull/17))
-- **Item catalog: 278 → 466 items.** The catalog had been seeded from a single save, so
-  plenty of real content showed up under its raw in-game id. Anything still unnamed remains
-  editable and moves between inventories normally.
-
-### v1.1.1
-
-- **Fix: saves edited on Xbox / PC Game Pass no longer corrupt.** The editor was adding a
-  UTF-8 byte-order mark that the Game Pass (WGS) build of the game does not write; on next
-  load the game reported a "file error". The editor now preserves whatever byte framing the
-  save already has (Steam saves keep their BOM). ([#13](https://github.com/Valkerran/PCEdit/issues/13))
-
-### v1.1.0
-
-- **Inventories — filter by world.** On a save that spans more than one planet, the Inventories
-  page gains a **World** filter. Inventories that can't be matched to a planet (drones, vehicles,
-  rockets, unplaced buffers) group under *Unknown world*.
-- **Teleport — worlds.** Each landmark shows the planet it sits on and the list filters to the
-  chosen destination world. Picking a destination world different from where the player stands
-  fills X / Y / Z from that world's arrival point, and *Use current position* now restores the
-  player's world as well as their coordinates.
-- **Teleport — multiplayer note** about non-host players (see [Using the editor](#teleport)).
-- **About page** now lists the game's default save-file locations per platform.
-- Fixes: *Use current position* no longer leaves a stale world selected.
-
 ## Using the editor
 
 ### Worlds (planets)
@@ -179,3 +135,53 @@ The xbox save files do not use world names for the file name. Instead they use a
 
 Linux Steam locations may depend on the drive you have installed the game to. Replace "~/.steam/steam" with the folder you installed your steam library to.
 
+## Changelog
+
+Full history and downloads are on the
+[Releases page](https://github.com/Valkerran/PCEdit/releases).
+
+### v1.2.2
+
+- **Fix: the AppImage's "report a bug" and homepage links pointed nowhere.** Every release
+  up to v1.2.1 shipped AppStream metadata naming a repository that does not exist, so those
+  links led to a 404 from the desktop entry. The application itself is unchanged from
+  v1.2.1. ([#28](https://github.com/Valkerran/PCEdit/pull/28))
+
+### v1.2.1
+
+- **Fix: the Linux AppImage now starts on distros with no system `libicu`.** A self-contained
+  build does not bundle ICU, and .NET aborts at startup when the system has none — so on
+  openSUSE Tumbleweed, and on minimal or container images generally, PCEdit would not launch
+  at all. The AppImage now carries its own ICU. It is larger for it: **56.5 MB, up from
+  43.0 MB**. Windows and macOS are unaffected — they use the ICU in the OS.
+  ([#4](https://github.com/Valkerran/PCEdit/issues/4))
+
+### v1.2.0
+
+- **Planet Crafter 2.102 (the *Skeo* update) is supported.** The save format barely moved:
+  one new key (`logisticsPaused`) on the unlocks section, and nothing else across all ten
+  sections, on Steam and Game Pass alike. Saves from 2.008 still open and still save back
+  unchanged. ([#17](https://github.com/Valkerran/PCEdit/pull/17))
+- **Item catalog: 278 → 466 items.** The catalog had been seeded from a single save, so
+  plenty of real content showed up under its raw in-game id. Anything still unnamed remains
+  editable and moves between inventories normally.
+
+### v1.1.1
+
+- **Fix: saves edited on Xbox / PC Game Pass no longer corrupt.** The editor was adding a
+  UTF-8 byte-order mark that the Game Pass (WGS) build of the game does not write; on next
+  load the game reported a "file error". The editor now preserves whatever byte framing the
+  save already has (Steam saves keep their BOM). ([#13](https://github.com/Valkerran/PCEdit/issues/13))
+
+### v1.1.0
+
+- **Inventories — filter by world.** On a save that spans more than one planet, the Inventories
+  page gains a **World** filter. Inventories that can't be matched to a planet (drones, vehicles,
+  rockets, unplaced buffers) group under *Unknown world*.
+- **Teleport — worlds.** Each landmark shows the planet it sits on and the list filters to the
+  chosen destination world. Picking a destination world different from where the player stands
+  fills X / Y / Z from that world's arrival point, and *Use current position* now restores the
+  player's world as well as their coordinates.
+- **Teleport — multiplayer note** about non-host players (see [Using the editor](#teleport)).
+- **About page** now lists the game's default save-file locations per platform.
+- Fixes: *Use current position* no longer leaves a stale world selected.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -68,8 +68,8 @@ Rules the pipelines enforce:
    differently — a notable size change, a new or dropped runtime dependency, a renamed or
    added artifact, a raised minimum OS. Say what changed, by how much, and why, and say who
    is *not* affected: a reader who sees "+13 MB" on Linux will wonder about their own
-   platform. Also add the same entry to the README changelog, which is what people read
-   before downloading.
+   platform. Also add the same entry to [`CHANGELOG.md`](CHANGELOG.md), which is what people
+   read before downloading.
 
    v1.2.1 is the worked example — bundling ICU took the AppImage from 43.0 MB to 56.5 MB,
    so its notes lead with those numbers, give the reason (it would not start at all on a


### PR DESCRIPTION
**The changelog is now [`CHANGELOG.md`](CHANGELOG.md).** People look for release history
under that filename, GitHub surfaces it from the repo header, and it grows at every release
while the README should stay a description of the tool. The README keeps a short
`## Changelog` section pointing at it, so the heading and its anchor still resolve for
anything linking here.

**Adds the v1.2.2 entry**, so the history is current with every published release: the
AppImage's "report a bug" and homepage links pointed at a repository that does not exist,
and the application itself is unchanged from v1.2.1.

**`CLAUDE.md` step 5 now requires the changelog entry alongside the version bump.** It only
mandated the bump, so a PR could leave `main` releasable and still undocumented — which is
how v1.2.0 and v1.2.1 both shipped with nothing in the changelog. Nothing downstream catches
that, because the release builds straight from `main`. The step also repeats the
packaging-change rule (size, runtime dependency, artifact name, minimum OS, and which
platforms are *not* affected), and carves out the bare "bump for development" after a
release, which has nothing to describe yet — otherwise the rule would be violated by this
very PR.

**`RELEASING.md` step 4** now names `CHANGELOG.md` as the place to mirror a release entry,
rather than the README.

**Bumps `<VersionPrefix>` to 1.2.3** (RELEASING.md step 5): 1.2.2 has shipped, so the prop
matched the newest tag and CI's version-guard warns on every PR until it moves.

One detail worth noting: the v1.1.0 entry linked to `(#teleport)`, an in-page anchor that
stopped resolving once the text moved to another file — repointed at `README.md#teleport`.

Verified: all five version entries transferred (v1.2.2 → v1.1.0), none left behind in the
README, and both generators re-run with no drift.
