### PR TITLE
Changelog: add the v1.2.3 entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ What changed in each release of PCEdit. Downloads for every version are on the
 [Releases page](https://github.com/Valkerran/PCEdit/releases); the newest is on the
 [latest release](https://github.com/Valkerran/PCEdit/releases/latest) page.
 
+## v1.2.3
+
+- **No change to the application.** Documentation and release process only, so the
+  binaries are identical to v1.2.2 apart from the version stamp: the release history
+  moved out of the README into this file, the Linux distro test matrix was completed
+  against the published v1.2.2 AppImage (six distros, glibc 2.31 to 2.44, system ICU 66
+  to 78 - all passing), and the release checklist now requires a changelog entry with
+  every version bump.
+
 ## v1.2.2
 
 - **Fix: the AppImage's "report a bug" and homepage links pointed nowhere.** Every release


### PR DESCRIPTION
Prerequisite for releasing 1.2.3: `<VersionPrefix>` is already 1.2.3 (bumped in #29), but
the version has no changelog entry. CLAUDE.md step 5 carves out only the bare "bump for
development" — this is the change that fills the version, so the entry belongs here.

The entry states plainly that **nothing in the application changed.** The only non-markdown
diff since v1.2.2 is `Directory.Build.props` itself:

```
CHANGELOG.md          | 51 +++++
CLAUDE.md             | 16 +-
Directory.Build.props |  2 +-
README.md             | 48 +---
RELEASING.md          |  4 +-
deploy/README.md      | 70 ++++--
```

So the v1.2.3 binaries differ from v1.2.2 by the version stamp alone. Someone comparing two
downloads shouldn't have to work that out for themselves.
