### PR TITLE
Bump <VersionPrefix> to 1.2.4 for development

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     and CI warns once <VersionPrefix> has caught up to the latest release tag.
   -->
   <PropertyGroup>
-    <VersionPrefix>1.2.3</VersionPrefix>
+    <VersionPrefix>1.2.4</VersionPrefix>
   </PropertyGroup>
 
   <!-- Licensing — GNU GPL v3 or later. Full text in the repo-root LICENSE file. -->


### PR DESCRIPTION
v1.2.3 has shipped, so `<VersionPrefix>` matched the newest release tag and CI's
`version-guard` warns on every PR until it moves. RELEASING.md step 5.

One line, patch bump — nothing else in this PR.

No `CHANGELOG.md` entry: this is the bare "bump for development" that CLAUDE.md step 5
explicitly carves out. 1.2.4 carries nothing yet, so its entry belongs with whatever change
fills it. (If the next work turns out to be a feature or new game-version support, this
becomes 1.3.0 instead — say so and I'll adjust before merge.)
