### PR TITLE
Add WSL2 launch profiles for the distro matrix

### DIFF
--- a/PCEdit.Desktop/Properties/launchSettings.json
+++ b/PCEdit.Desktop/Properties/launchSettings.json
@@ -1,0 +1,23 @@
+{
+  "profiles": {
+    "PCEdit.Desktop": {
+      "commandName": "Project"
+    },
+    "WSL-Ubuntu-20.04": {
+      "commandName": "WSL2",
+      "distributionName": "Ubuntu-20.04"
+    },
+    "WSL-Ubuntu-22.04": {
+      "commandName": "WSL2",
+      "distributionName": "Ubuntu-22.04"
+    },
+    "WSL-Ubuntu-24.04": {
+      "commandName": "WSL2",
+      "distributionName": "Ubuntu-24.04"
+    },
+    "WSL-FedoraLinux-43": {
+      "commandName": "WSL2",
+      "distributionName": "FedoraLinux-43"
+    }
+  }
+}


### PR DESCRIPTION
Salvaged from an abandoned local branch (`bugs/libici-bundling`) before deleting it.

Adds `PCEdit.Desktop/Properties/launchSettings.json` with one run profile per WSL2 distro used for the portability checks in `deploy/README.md` — Ubuntu 20.04 / 22.04 / 24.04 and FedoraLinux-43 — plus the plain project profile, so the default Windows run is unchanged.

The other two changes on that branch were deliberately left behind: an unconditional `Microsoft.ICU.ICU4C.Runtime` reference (superseded by the `linux-*`-gated wiring on `main`, which the unconditional form would break by pulling ICU into the Windows and macOS publishes), and an `<Authors>` / `<Copyright>` rename, which is an attribution decision that deserves its own change.

Tooling only. No version bump or changelog entry: nothing in the build or the shipped app changes.