### PR TITLE
Publish under Valkerran

### DIFF
--- a/DISCLAIMER.md
+++ b/DISCLAIMER.md
@@ -19,4 +19,4 @@ or supported by the developers or publishers of *The Planet Crafter*.
 
 This text is the single source mirrored by the in-app disclaimer
 (`Disclaimer_Body` in the string catalog), the AppStream `<description>` in
-`deploy/com.waltersmart.pcedit.metainfo.xml`, and the release notes.
+`deploy/com.valkerran.pcedit.metainfo.xml`, and the release notes.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,8 +18,8 @@
 
   <!-- Licensing — GNU GPL v3 or later. Full text in the repo-root LICENSE file. -->
   <PropertyGroup>
-    <Authors>Walter Smart</Authors>
-    <Copyright>Copyright (C) 2026 Walter Smart</Copyright>
+    <Authors>Valkerran</Authors>
+    <Copyright>Copyright (C) 2026 Valkerran</Copyright>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
   </PropertyGroup>
 

--- a/deploy/com.valkerran.pcedit.metainfo.xml
+++ b/deploy/com.valkerran.pcedit.metainfo.xml
@@ -67,7 +67,7 @@
   <url type="homepage">https://github.com/Valkerran/PCEdit</url>
   <url type="bugtracker">https://github.com/Valkerran/PCEdit/issues</url>
   <developer id="com.valkerran">
-    <name>Walter Smart</name>
+    <name>Valkerran</name>
   </developer>
   <categories>
     <category>Utility</category>

--- a/deploy/pcedit.pupnet.conf
+++ b/deploy/pcedit.pupnet.conf
@@ -26,9 +26,9 @@ AppLicenseFile = ../LICENSE
 AppChangeFile =
 
 # PUBLISHER
-PublisherName = Walter Smart
+PublisherName = Valkerran
 PublisherId = com.valkerran
-PublisherCopyright = Copyright (C) 2026 Walter Smart
+PublisherCopyright = Copyright (C) 2026 Valkerran
 PublisherLinkName = Source code
 PublisherLinkUrl = https://github.com/Valkerran/PCEdit
 PublisherEmail =

--- a/tools/i18n/gen_metainfo.py
+++ b/tools/i18n/gen_metainfo.py
@@ -103,7 +103,7 @@ def main() -> int:
     w('  <url type="bugtracker">https://github.com/Valkerran/PCEdit/issues</url>')
 
     w('  <developer id="com.valkerran">')
-    w("    <name>Walter Smart</name>")
+    w("    <name>Valkerran</name>")
     w("  </developer>")
 
     w("  <categories>")


### PR DESCRIPTION
The author / copyright holder is named in four places that all have to agree:

| Where | Effect |
|---|---|
| `<Authors>` / `<Copyright>` in `Directory.Build.props` | Stamped into every assembly |
| `PublisherName` / `PublisherCopyright` in `deploy/pcedit.pupnet.conf` | The AppImage's packaging metadata |
| `<developer><name>` in `tools/i18n/gen_metainfo.py` | The AppStream store listing |
| `deploy/com.valkerran.pcedit.metainfo.xml` | Generated — regenerated here, so CI's drift check passes |

Also fixes a stale filename in `DISCLAIMER.md`, which still pointed at `deploy/com.waltersmart.pcedit.metainfo.xml` (renamed to `com.valkerran.pcedit.metainfo.xml` some time ago).

Verified: `grep -i walter` over the repo returns nothing, and both test projects pass locally (65 + 158).

No version bump or changelog entry: this is attribution metadata, nothing changes for someone using the app, and `<VersionPrefix>` 1.2.4 is already ahead of v1.2.3 and unreleased.